### PR TITLE
비동기 DB 처리 제거 및 동기 sqlmodel 방식으로 변경

### DIFF
--- a/src/api/post.py
+++ b/src/api/post.py
@@ -39,7 +39,7 @@ class DeletePostResponse(BaseModel):
 @post_router.post(
     "/posts", response_model=PostResponse, status_code=status.HTTP_201_CREATED
 )
-async def create_post(
+def create_post(
     post: PostRequest,
     session: SessionDep,
     author: str = Header(..., alias="Author"),
@@ -64,7 +64,7 @@ async def create_post(
 @post_router.get(
     "/posts", response_model=list[PostResponse], status_code=status.HTTP_200_OK
 )
-async def get_posts(session: SessionDep) -> list[PostResponse]:
+def get_posts(session: SessionDep) -> list[PostResponse]:
     stmt = select(Post)
     results = session.exec(stmt).all()
     return [
@@ -77,7 +77,7 @@ async def get_posts(session: SessionDep) -> list[PostResponse]:
     response_model=PostResponse,
     status_code=status.HTTP_200_OK,
 )
-async def get_post(session: SessionDep, post_id: str) -> PostResponse:
+def get_post(session: SessionDep, post_id: str) -> PostResponse:
     stmt = select(Post).where(Post.id == post_id)
     post = session.exec(stmt).first()
 
@@ -96,7 +96,7 @@ async def get_post(session: SessionDep, post_id: str) -> PostResponse:
     response_model=PostResponse,
     status_code=status.HTTP_200_OK,
 )
-async def update_post(
+def update_post(
     post_id: str,
     post_data: PostRequest,
     session: SessionDep,
@@ -133,7 +133,7 @@ async def update_post(
     response_model=DeletePostResponse,
     status_code=status.HTTP_200_OK,
 )
-async def delete_post(
+def delete_post(
     post_id: str,
     session: SessionDep,
     author: str = Header(..., alias="Author"),

--- a/src/main.py
+++ b/src/main.py
@@ -1,7 +1,6 @@
 from typing import Annotated
 
 from fastapi import Depends, FastAPI
-from fastapi.concurrency import asynccontextmanager
 from sqlmodel import Session
 
 from src.api.health import health_router
@@ -11,8 +10,7 @@ from src.sqlite3.connection import get_session, init_db
 SessionDep = Annotated[Session, Depends(get_session)]
 
 
-@asynccontextmanager
-async def lifespan(app: FastAPI):
+def lifespan(app: FastAPI):
     init_db()
     yield
 

--- a/src/sqlite3/connection.py
+++ b/src/sqlite3/connection.py
@@ -16,8 +16,6 @@ ENGINE = create_engine(
     max_overflow=10,
 )
 
-SQLModel.metadata.create_all(ENGINE)
-
 
 def init_db():
     SQLModel.metadata.create_all(ENGINE)


### PR DESCRIPTION
* SQLModel의 제한된 비동기 지원으로 인해 기존의 비동기 DB 처리 로직을 모두 동기 방식으로 전환합니다.